### PR TITLE
update seasons/rounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,9 +271,6 @@ $ ./test.sh
 - `{uint16_t} season_id` - (primary key) season_id
 - `{string} description` - season description
 - `{vector<uint16_t>} round_ids` - round ids participating in this season
-- `{set<name>} grant_ids` - grants IDs participating
-- `{set<name>} user_ids` - user IDs participating
-- `{vector<extended_asset>} donated_tokens` - donated tokens
 - `{double} match_value` - total matching pool value for this season
 - `{time_point_sec} start_at` - start at time
 - `{time_point_sec} end_at` - end at time
@@ -289,9 +286,6 @@ $ ./test.sh
     "season_id": 1,
     "description": "Season #1",
     "round_ids": [101, 102, 103],
-    "grant_ids": ["grant1"],
-    "user_ids": ["user1.eosn"],
-    "donated_tokens": [{"contract": "eosio.token", "quantity": "100.0000 EOS"}],
     "match_value": 100000,
     "start_at": "2020-12-06T00:00:00",
     "end_at": "2020-12-12T00:00:00",

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ $ ./test.sh
 
 ## TABLE `globals`
 
-- `{uint16_t} round_id` - round ID (0 = not active)
+- `{uint16_t} season_id` - season ID (0 = not active)
 - `{uint64_t} grant_fee` - grant fee (bips - 1/100 1%)
 - `{uint64_t} bounty_fee` - bounty fee (bips - 1/100 1%)
 - `{name} login_contract` - EOSN Login contract
@@ -104,7 +104,7 @@ $ ./test.sh
 
 ```json
 {
-    "round_id": 1,
+    "season_id": 1,
     "grant_fee": 500,
     "bounty_fee": 500,
     "login_contractt": "login.eosn",
@@ -219,7 +219,7 @@ $ ./test.sh
 ```json
 {
     "grant_id": "grant1",
-    "round_id": 1,
+    "round_id": 101,
     "total_users": 2,
     "sum_value": 150.0,
     "sum_boost": 325.0,
@@ -260,43 +260,18 @@ $ ./test.sh
 }
 
 ```
+
 ## TABLE `seasons`
 
 ### params
 
-- `{uint16_t} season_id` - (primary key)
-- `{vector<uint16_t>} round_ids` - round ids in this season
-- `{string} description` - grant text description
-- `{double} match_value` - estimated total matching pool value for this season
-- `{time_point_sec} start_at` - start at time
-- `{time_point_sec} end_at` - end at time
-
-### example
-
-```json
-{
-    "season_id": 1,
-    "round_ids": [101, 102],
-    "description": "Season #1",
-    "match_value": 100000,
-    "start_at": "2020-12-06T00:00:00",
-    "end_at": "2020-12-12T00:00:00",
-}
-```
-
-## TABLE `rounds`
-
-### params
-
-- `{uint64_t} round_id` - (primary key) matching rounds
-- `{string} description` - grant text description
+- `{uint16_t} season_id` - (primary key) season_id
+- `{string} description` - season description
+- `{vector<uint16_t>} round_ids` - round ids participating in this season
 - `{set<name>} grant_ids` - grants IDs participating
 - `{set<name>} user_ids` - user IDs participating
 - `{vector<extended_asset>} donated_tokens` - donated tokens
-- `{double} match_value` - total value of the matching pool
-- `{double} sum_value` - total value donated this round
-- `{double} sum_boost` - total boost received this round
-- `{double} sum_square` - square of total sqrt sum
+- `{double} match_value` - total matching pool value for this season
 - `{time_point_sec} start_at` - start at time
 - `{time_point_sec} end_at` - end at time
 - `{time_point_sec} submission_start_at` - submission start time
@@ -308,8 +283,46 @@ $ ./test.sh
 
 ```json
 {
-    "round_id": 1,
+    "season_id": 1,
+    "description": "Season #1",
+    "round_ids": [101, 102, 103],
+    "grant_ids": ["grant1"],
+    "user_ids": ["user1.eosn"],
+    "donated_tokens": [{"contract": "eosio.token", "quantity": "100.0000 EOS"}],
+    "match_value": 100000,
+    "start_at": "2020-12-06T00:00:00",
+    "end_at": "2020-12-12T00:00:00",
+    "submission_start_at": "2020-11-06T00:00:00",
+    "submission_end_at": "2020-12-06T00:00:00",
+    "created_at": "2020-12-06T00:00:00",
+    "updated_at": "2020-12-06T00:00:00",
+}
+```
+
+## TABLE `rounds`
+
+### params
+
+- `{uint64_t} round` - (primary key) matching rounds
+- `{string} description` - grant text description
+- `{uint16_t} season_id` - season ID
+- `{set<name>} grant_ids` - grants IDs participating
+- `{set<name>} user_ids` - user IDs participating
+- `{vector<extended_asset>} donated_tokens` - donated tokens
+- `{double} match_value` - estimated value of the matching pool
+- `{double} sum_value` - total value donated this round
+- `{double} sum_boost` - total boost received this round
+- `{double} sum_square` - square of total sqrt sum
+- `{time_point_sec} created_at` - created at time
+- `{time_point_sec} updated_at` - updated at time
+
+### example
+
+```json
+{
+    "round": 101,
     "description": "Grant Round #1",
+    "season_id": 1,
     "grant_ids": ["grant1"],
     "user_ids": ["user1.eosn"],
     "donated_tokens": [{"contract": "eosio.token", "quantity": "100.0000 EOS"}],
@@ -317,10 +330,6 @@ $ ./test.sh
     "sum_value": 12345,
     "sum_boost": 3231,
     "sum_square": 423451.1233,
-    "start_at": "2020-12-06T00:00:00",
-    "end_at": "2020-12-12T00:00:00",
-    "submission_start_at": "2020-12-06T00:00:00",
-    "submission_end_at": "2020-12-12T00:00:00",
     "created_at": "2020-12-06T00:00:00",
     "updated_at": "2020-12-06T00:00:00",
 }
@@ -364,19 +373,22 @@ $ cleos push action app.pomelo setconfig '[1, 500, 500, "login.eosn", "fee.pomel
 
 ## ACTION `setseason`
 
+Set season parameters. If optional parameter undefined - don't change it. If all parameters undefined - delete
+
 ### params
 
-- `{uint16_t} season_id` - season ID
-- `{vector<uint16_t>} round_ids` - round ids in this season
-- `{optional<time_point_sec>} start_at` - start at time
-- `{optional<time_point_sec>} end_at` - end at time
+- `{uint16_t} season_id` - season ID (0 = not active)
+- `{optional<time_point_sec>} start_at` - round start time
+- `{optional<time_point_sec>} end_at` - round end time
+- `{optional<time_point_sec>} submission_start_at` - round submission start time
+- `{optional<time_point_sec>} submission_end_at` - round submission end time
 - `{optional<string>} description` - season description
-- `{optional<value>} match_value` - estimated total matching pool value for this season
+- `{optional<double>} match_value` - match value (for information purposes)
 
 ### example
 
 ```bash
-$ cleos push action app.pomelo setseason '[1, "2021-08-20T10:00:00", "2021-10-28T10:00:00", [101,102], "Season #1", 100000]' -p app.pomelo
+$ cleos push action app.pomelo setseason '[1, "2021-05-19T20:00:00", "2021-05-25T20:00:00", "2021-05-19T20:00:00", "2021-05-25T20:00:00", "Season 1", 100000]' -p app.pomelo
 ```
 
 ## ACTION `setproject`
@@ -417,22 +429,19 @@ $ cleos push action app.pomelo enable '["grant", "grant1", "ok"]' -p app.pomelo
 
 ## ACTION `setround`
 
-Create/update round. If parameter not set - don't modify it
+Create/update round. If a parameter is null - don't change it
 
 ### params
 
 - `{uint16_t} round_id` - round id
-- `{optional<time_point_sec>} start_at` - round start time
-- `{optional<time_point_sec>} end_at` - round end time
-- `{optional<time_point_sec>} submission_start_at` - round submission start time
-- `{optional<time_point_sec>} submission_end_at` - round submission end time
+- `{uint16_t} season_id` - season id
 - `{optional<string>} description` - grant description
-- `{optional<double>} match_value` - matching pool value
+- `{optional<double>} match_value` - total value of the matching pool
 
 ### example
 
 ```bash
-$ cleos push action app.pomelo setround '[1, "2021-05-19T20:00:00", "2021-05-25T20:00:00", "2021-05-19T20:00:00", "2021-05-25T20:00:00", "Grant Round #1", 100000]' -p app.pomelo
+$ cleos push action app.pomelo setround '[101, 1, "Grant Round #1", 100000]' -p app.pomelo
 ```
 
 ## ACTION `joinround`
@@ -449,7 +458,7 @@ Adds grant to round
 ### example
 
 ```bash
-$ cleos push action app.pomelo joinround '["grant1", 1]' -p app.pomelo -p 123.eosn
+$ cleos push action app.pomelo joinround '["grant1", 101]' -p app.pomelo -p 123.eosn
 ```
 
 ## ACTION `unjoinround`
@@ -466,7 +475,7 @@ Remove grant from round and update all matchings
 ### example
 
 ```bash
-$ cleos push action app.pomelo unjoinround '["grant1", 1]' -p app.pomelo
+$ cleos push action app.pomelo unjoinround '["grant1", 101]' -p app.pomelo
 ```
 
 ## ACTION `cleartable`
@@ -482,7 +491,7 @@ Clear table
 ### example
 
 ```bash
-$ cleos push action app.pomelo cleartable '["transfers", 1, 500]' -p app.pomelo
+$ cleos push action app.pomelo cleartable '["transfers", 101, 500]' -p app.pomelo
 ```
 
 ## ACTION `removeuser`

--- a/README.md
+++ b/README.md
@@ -158,10 +158,11 @@ $ ./test.sh
 |--------------- |------------------|------------|
 | `byfrom`       | 2                | i64        |
 | `byuser`       | 3                | i64        |
-| `byround`      | 4                | i64        |
-| `bygrant`      | 5                | i64        |
-| `byvalue`      | 6                | i64        |
-| `bycreated`    | 7                | i64        |
+| `byseason`     | 4                | i64        |
+| `byround`      | 5                | i64        |
+| `bygrant`      | 6                | i64        |
+| `byvalue`      | 7                | i64        |
+| `bycreated`    | 8                | i64        |
 
 ### params
 
@@ -172,6 +173,7 @@ $ ./test.sh
 - `{asset} fee` - fee charged and sent to `global.fee_account`
 - `{string} memo` - transfer memo
 - `{name} user_id` - Pomelo user account ID
+- `{uint16_t} season_id` - participating season ID
 - `{uint16_t} round_id` - participating round ID
 - `{name} project_type` - project type ("grant" / "bounty")
 - `{name} project_id` - project ID
@@ -190,7 +192,8 @@ $ ./test.sh
     "fee": "1.0000 EOS",
     "memo": "grant:grant1",
     "user_id": "user1.eosn",
-    "round": 1,
+    "season_id": 1,
+    "round_id": 101,
     "project_type": "grant",
     "project_id": "grant1",
     "value": 100.0,
@@ -303,7 +306,7 @@ $ ./test.sh
 
 ### params
 
-- `{uint64_t} round` - (primary key) matching rounds
+- `{uint64_t} round_id` - (primary key) matching rounds
 - `{string} description` - grant text description
 - `{uint16_t} season_id` - season ID
 - `{set<name>} grant_ids` - grants IDs participating
@@ -320,7 +323,7 @@ $ ./test.sh
 
 ```json
 {
-    "round": 101,
+    "round_id": 101,
     "description": "Grant Round #1",
     "season_id": 1,
     "grant_ids": ["grant1"],

--- a/app.pomelo.cpp
+++ b/app.pomelo.cpp
@@ -126,24 +126,6 @@ void pomelo::donate_grant(const name grant_id, const extended_asset ext_quantity
         row.sum_square += new_square - old_square;
         row.updated_at = current_time_point();
     });
-
-    // update season
-    pomelo::seasons_table seasons( get_self(), get_self().value );
-    auto & season = seasons.get(round_itr->season_id, "pomelo::donate_grant: [season_id] does not exists");
-    seasons.modify( season, get_self(), [&]( auto & row ) {
-        // TO-DO refactor adding extended asset into dedicated method
-        // row.donated_tokens = sum_extended_asset( row.donated_tokens, ext_quantity );
-        bool added = false;
-        for ( extended_asset & donated_token : row.donated_tokens ) {
-            if ( donated_token.get_extended_symbol() == ext_quantity.get_extended_symbol() ) {
-                donated_token += ext_quantity;
-                added = true;
-            }
-        }
-        if (!added) row.donated_tokens.push_back(ext_quantity);
-        if( get_index(row.user_ids, user_id) == -1) row.user_ids.push_back(user_id);
-        row.updated_at = current_time_point();
-    });
 }
 
 void pomelo::save_transfer( const name from, const name to, const extended_asset ext_quantity, const asset fee, const string& memo, const name project_type, const name project_id, const double value )

--- a/app.pomelo.cpp
+++ b/app.pomelo.cpp
@@ -150,6 +150,7 @@ void pomelo::save_transfer( const name from, const name to, const extended_asset
 {
     const auto user_id = get_user_id( from );
     const auto round_id = get_active_round( project_id );
+    const auto season_id = get_globals().season_id;
 
     pomelo::transfers_table transfers( get_self(), get_self().value );
     transfers.emplace( get_self(), [&]( auto & row ) {
@@ -160,6 +161,7 @@ void pomelo::save_transfer( const name from, const name to, const extended_asset
         row.fee = fee;
         row.memo = memo;
         row.user_id = user_id;
+        row.season_id = season_id;
         row.round_id = round_id;
         row.project_type = project_type;
         row.project_id = project_id;

--- a/app.pomelo.hpp
+++ b/app.pomelo.hpp
@@ -234,10 +234,11 @@ public:
      * |--------------- |------------------|------------|
      * | `byfrom`       | 2                | i64        |
      * | `byuser`       | 3                | i64        |
-     * | `byround`      | 4                | i64        |
-     * | `bygrant`      | 5                | i64        |
-     * | `byvalue`      | 6                | i64        |
-     * | `bycreated`    | 7                | i64        |
+     * | `byseason`     | 4                | i64        |
+     * | `byround`      | 5                | i64        |
+     * | `bygrant`      | 6                | i64        |
+     * | `byvalue`      | 7                | i64        |
+     * | `bycreated`    | 8                | i64        |
      *
      * ### params
      *
@@ -248,7 +249,8 @@ public:
      * - `{asset} fee` - fee charged and sent to `global.fee_account`
      * - `{string} memo` - transfer memo
      * - `{name} user_id` - Pomelo user account ID
-     * - `{uint16_t} season_id` - season ID (0 if outside season)
+     * - `{uint16_t} season_id` - participating season ID
+     * - `{uint16_t} round_id` - participating round ID
      * - `{name} project_type` - project type ("grant" / "bounty")
      * - `{name} project_id` - project ID
      * - `{double} value` - valuation at time of received
@@ -267,6 +269,7 @@ public:
      *     "memo": "grant:grant1",
      *     "user_id": "user1.eosn",
      *     "season_id": 1,
+     *     "round_id": 101,
      *     "project_type": "grant",
      *     "project_id": "grant1",
      *     "value": 100.0,
@@ -283,6 +286,7 @@ public:
         asset                   fee;
         string                  memo;
         name                    user_id;
+        uint16_t                season_id;
         uint16_t                round_id;
         name                    project_type;
         name                    project_id;
@@ -293,6 +297,7 @@ public:
         uint64_t primary_key() const { return transfer_id; };
         uint64_t byfrom() const { return from.value; };
         uint64_t byuser() const { return user_id.value; };
+        uint64_t byseason() const { return season_id; };
         uint64_t byround() const { return round_id; };
         uint64_t byproject() const { return project_id.value; };
         uint64_t byvalue() const { return static_cast<uint64_t> ( value * VALUE_SYM.get_symbol().precision() ); };
@@ -302,6 +307,7 @@ public:
     typedef eosio::multi_index< "transfers"_n, transfers_row,
         indexed_by< "byfrom"_n, const_mem_fun<transfers_row, uint64_t, &transfers_row::byfrom> >,
         indexed_by< "byuser"_n, const_mem_fun<transfers_row, uint64_t, &transfers_row::byuser> >,
+        indexed_by< "byseason"_n, const_mem_fun<transfers_row, uint64_t, &transfers_row::byseason> >,
         indexed_by< "byround"_n, const_mem_fun<transfers_row, uint64_t, &transfers_row::byround> >,
         indexed_by< "byproject"_n, const_mem_fun<transfers_row, uint64_t, &transfers_row::byproject> >,
         indexed_by< "byvalue"_n, const_mem_fun<transfers_row, uint64_t, &transfers_row::byvalue> >,
@@ -410,7 +416,7 @@ public:
      *
      * ### params
      *
-     * - `{uint64_t} round` - (primary key) matching rounds
+     * - `{uint16_t} round_id` - (primary key) matching rounds
      * - `{string} description` - grant text description
      * - `{uint16_t} season_id` - season ID
      * - `{set<name>} grant_ids` - grants IDs participating
@@ -427,7 +433,7 @@ public:
      *
      * ```json
      * {
-     *     "round": 101,
+     *     "round_id": 101,
      *     "description": "Grant Round #1",
      *     "season_id": 1,
      *     "grant_ids": ["grant1"],
@@ -443,7 +449,7 @@ public:
      * ```
      */
     struct [[eosio::table("rounds")]] rounds_row {
-        uint64_t                round;
+        uint16_t                round_id;
         string                  description;
         uint16_t                season_id;
         vector<name>            grant_ids;
@@ -456,7 +462,7 @@ public:
         time_point_sec          created_at;
         time_point_sec          updated_at;
 
-        uint64_t primary_key() const { return round; };
+        uint64_t primary_key() const { return round_id; };
         uint64_t byseason() const { return season_id; };
     };
     typedef eosio::multi_index< "rounds"_n, rounds_row,

--- a/app.pomelo.hpp
+++ b/app.pomelo.hpp
@@ -114,9 +114,6 @@ public:
         uint16_t            season_id;
         string              description;
         vector<uint16_t>    round_ids;
-        vector<name>        grant_ids;
-        vector<name>        user_ids;
-        vector<extended_asset>  donated_tokens;
         double              match_value;
         time_point_sec      start_at;
         time_point_sec      end_at;
@@ -474,7 +471,7 @@ public:
      *
      * ### params
      *
-     * - `{uint16_t} round_id` - round ID (0 = not active)
+     * - `{uint16_t} season_id` - season ID (0 = not active)
      * - `{uint64_t} grant_fee` - grant fee (bips - 1/100 1%)
      * - `{uint64_t} bounty_fee` - bounty fee (bips - 1/100 1%)
      * - `{name} login_contract` - EOSN Login contract
@@ -487,7 +484,7 @@ public:
      * ```
      */
     [[eosio::action]]
-    void setconfig( const optional<uint16_t> round_id, const optional<uint64_t> grant_fee, const optional<uint64_t> bounty_fee, const optional<name> login_contract, const optional<name> fee_account );
+    void setconfig( const optional<uint16_t> season_id, const optional<uint64_t> grant_fee, const optional<uint64_t> bounty_fee, const optional<name> login_contract, const optional<name> fee_account );
 
     /**
      * ## ACTION `setseason`

--- a/app.pomelo.hpp
+++ b/app.pomelo.hpp
@@ -79,9 +79,6 @@ public:
      * - `{uint16_t} season_id` - (primary key) season_id
      * - `{string} description` - season description
      * - `{vector<uint16_t>} round_ids` - round ids participating in this season
-     * - `{set<name>} grant_ids` - grants IDs participating
-     * - `{set<name>} user_ids` - user IDs participating
-     * - `{vector<extended_asset>} donated_tokens` - donated tokens
      * - `{double} match_value` - total matching pool value for this season
      * - `{time_point_sec} start_at` - start at time
      * - `{time_point_sec} end_at` - end at time
@@ -97,9 +94,6 @@ public:
      *      "season_id": 1,
      *      "description": "Season #1",
      *      "round_ids": [101, 102, 103],
-     *      "grant_ids": ["grant1"],
-     *      "user_ids": ["user1.eosn"],
-     *      "donated_tokens": [{"contract": "eosio.token", "quantity": "100.0000 EOS"}],
      *      "match_value": 100000,
      *      "start_at": "2020-12-06T00:00:00",
      *      "end_at": "2020-12-12T00:00:00",

--- a/app.pomelo.hpp
+++ b/app.pomelo.hpp
@@ -490,7 +490,7 @@ public:
      *
      * ### params
      *
-     * - `{uint16_t} season_id` - season ID (0 = not active)
+     * - `{uint16_t} season_id` - season ID (should be > 0)
      * - `{optional<time_point_sec>} start_at` - round start time
      * - `{optional<time_point_sec>} end_at` - round end time
      * - `{optional<time_point_sec>} submission_start_at` - round submission start time

--- a/src/actions.cpp
+++ b/src/actions.cpp
@@ -233,7 +233,7 @@ void pomelo::setround(  const uint16_t round_id,
 {
     require_auth( get_self() );
 
-    check( season_id > 0,  "pomelo::setround: [season_id] must exist");)
+    check( season_id > 0,  "pomelo::setround: [season_id] must exist");
     pomelo::rounds_table rounds( get_self(), get_self().value );
     pomelo::seasons_table seasons( get_self(), get_self().value );
 
@@ -243,12 +243,14 @@ void pomelo::setround(  const uint16_t round_id,
     if ( get_index(season.round_ids, round_id) == -1 ) {
         seasons.modify( season, get_self(), [&]( auto & row ) {
             row.round_ids.push_back(round_id);
-            check( row.start_at >= current_time_point(), "pomelo::setround: [current_time_point] must be before [start_at]");
+            // check( row.start_at >= current_time_point(), "pomelo::setround: [current_time_point] must be before [start_at]");
         });
     }
 
     const auto insert = [&]( auto & row ) {
         row.round_id = round_id;
+        check(row.season_id == 0 || row.season_id == season_id, "pomelo::setround: [round_id] already exists in another season");
+        row.season_id = season_id;
         if(description) row.description = *description;
         if(match_value) row.match_value = *match_value;
         row.updated_at = current_time_point();

--- a/src/actions.cpp
+++ b/src/actions.cpp
@@ -244,7 +244,7 @@ void pomelo::setround(  const uint16_t round_id,
     }
 
     const auto insert = [&]( auto & row ) {
-        row.round = round_id;
+        row.round_id = round_id;
         if(description) row.description = *description;
         if(match_value) row.match_value = *match_value;
         row.updated_at = current_time_point();

--- a/src/actions.cpp
+++ b/src/actions.cpp
@@ -52,9 +52,9 @@ void pomelo::setseason( const uint16_t season_id, const optional<time_point_sec>
 
         // validate times
         check( row.end_at > row.start_at, "pomelo::setseason: [end_at] must be after [start_at]");
-        check( row.end_at.sec_since_epoch() - row.start_at.sec_since_epoch() >= DAY * 7, "pomelo::setseason: active minimum period must be at least 7 days");
+        check( row.end_at.sec_since_epoch() - row.start_at.sec_since_epoch() >= DAY * 1, "pomelo::setseason: active minimum period must be at least 1 day");
         check( row.submission_end_at > row.submission_start_at, "pomelo::setseason: [submission_end_at] must be after [submission_start_at]");
-        check( row.submission_end_at.sec_since_epoch() - row.submission_start_at.sec_since_epoch() >= DAY * 7, "pomelo::setseason: submission minimum period must be at least 7 days");
+        check( row.submission_end_at.sec_since_epoch() - row.submission_start_at.sec_since_epoch() >= DAY * 1, "pomelo::setseason: submission minimum period must be at least 1 day");
         check( row.submission_start_at <= row.start_at, "pomelo::setseason: [submission_start_at] must be before [start_at]");
         check( row.submission_end_at <= row.end_at, "pomelo::setseason: [submission_end_at] must be before [end_at]");
     };

--- a/src/actions.cpp
+++ b/src/actions.cpp
@@ -116,19 +116,19 @@ void pomelo::joinround( const name grant_id, const uint16_t round_id )
     const auto & round = rounds.get( round_id, "pomelo::joinround: [round_id] does not exist");
     const auto & season = seasons.get( round.season_id, "pomelo::joinround: [round.season_id] does not exist");
     check( get_index(round.grant_ids, grant_id ) == -1, "pomelo::joinround: grant already exists in this round");
-    check( get_index(season.grant_ids, grant_id ) == -1, "pomelo::joinround: grant already exists in this season");
     check( season.submission_start_at.sec_since_epoch() <= now, "pomelo::joinround: [round_id] submission period has not started");
     check( now <= season.submission_end_at.sec_since_epoch(), "pomelo::joinround: [round_id] submission period has ended");
+
+    for(const auto ex_round_id: season.round_ids){
+        const auto round = rounds.get(ex_round_id, "pomelo::joinround: bad existing round in a season");
+        check( get_index(round.grant_ids, grant_id ) == -1, "pomelo::joinround: grant already exists in this season");
+    }
 
     rounds.modify( round, get_self(), [&]( auto & row ) {
         row.grant_ids.push_back(grant_id);
         row.updated_at = current_time_point();
     });
 
-    seasons.modify( season, get_self(), [&]( auto & row ) {
-        row.grant_ids.push_back(grant_id);
-        row.updated_at = current_time_point();
-    });
 }
 
 // @admin

--- a/src/actions.cpp
+++ b/src/actions.cpp
@@ -33,6 +33,9 @@ void pomelo::token( const symbol sym, const name contract, const uint64_t min_am
 void pomelo::setseason( const uint16_t season_id, const optional<time_point_sec> start_at, const optional<time_point_sec> end_at, const optional<time_point_sec> submission_start_at, const optional<time_point_sec> submission_end_at, const optional<string> description, const optional<double> match_value )
 {
     require_auth( get_self() );
+
+    check( season_id > 0, "pomelo::setseason: [season_id] must be positive");
+
     pomelo::seasons_table seasons( get_self(), get_self().value );
     const auto itr = seasons.find( season_id );
 
@@ -230,6 +233,7 @@ void pomelo::setround(  const uint16_t round_id,
 {
     require_auth( get_self() );
 
+    check( season_id > 0,  "pomelo::setround: [season_id] must exist");)
     pomelo::rounds_table rounds( get_self(), get_self().value );
     pomelo::seasons_table seasons( get_self(), get_self().value );
 

--- a/src/getters.cpp
+++ b/src/getters.cpp
@@ -52,14 +52,16 @@ bool pomelo::is_user( const name user_id )
 
 void pomelo::validate_round( const uint16_t round_id )
 {
-    pomelo::rounds_table _rounds( get_self(), get_self().value );
+    pomelo::rounds_table rounds( get_self(), get_self().value );
+    pomelo::seasons_table seasons( get_self(), get_self().value );
 
     check(round_id != 0, "pomelo::validate_round: [round_id] is not active");
 
     const auto now = current_time_point().sec_since_epoch();
-    const auto rounds = _rounds.get( round_id, "pomelo::validate_round: [round_id] not found");
-    check(rounds.start_at.sec_since_epoch() <= now, "pomelo::validate_round: [round_id] has not started");
-    check(now <= rounds.end_at.sec_since_epoch(), "pomelo::validate_round: [round_id] has expired");
+    const auto round = rounds.get( round_id, "pomelo::validate_round: [round_id] not found");
+    const auto season = seasons.get( round.season_id, "pomelo::validate_round: [season_id] not found");
+    check(season.start_at.sec_since_epoch() <= now, "pomelo::validate_round: [season_id] has not started");
+    check(now <= season.end_at.sec_since_epoch(), "pomelo::validate_round: [season_id] has expired");
 }
 
 uint16_t pomelo::get_active_round( const name grant_id )


### PR DESCRIPTION
Ref: https://github.com/pomelo-io/pomelo-rest-api/issues/191#issuecomment-945137937

A few changes related to this:

- [x] Remove `start_at`, `end_at`, `submission_start_at`,`submission_end_at` from `rounds` and move that data into `seasons`
- [x] Seasons are first created, then rounds join the season (that way the start/end metadata belongs to seasons)
> That way if there are 10 rounds and we decide to modify the start/end of the season, we can simply modify the season instead of replicating this change over each individual round.
- [x] `grand_id` can only join one round per season
  - [x] need to add `grand_ids` to seasons
 
- [x] add donated tokens to season (for informational purposes)
  - [x] TO-DO refactor adding extended asset into dedicated method

```c++
row.donated_tokens = sum_extended_asset( row.donated_tokens, ext_quantity );
```

## Action changes

```c++
void setseason( const uint16_t season_id, const optional<time_point_sec> start_at, const optional<time_point_sec> end_at, const optional<time_point_sec> submission_start_at, const optional<time_point_sec> submission_end_at, const optional<string> description, const optional<double> match_value );
```

```c++
void setround( const uint16_t round_id, const uint16_t season_id, const optional<string> description, const optional<double> match_value );
```

## Rename `round` => `round_id` https://github.com/pomelo-io/pomelo.app/pull/7/commits/1530b226206d2cf701d506a6efba08cdd1d27370

- [x] add `season_id` to transfers
- [x] rename `round` => `round_id`
- [x]  change `round_id` type `uint64_t` => `uint16_t`